### PR TITLE
Reduce allocations, Remove GetNode(), Consolidate ImGui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Godot 4+ specific ignores
 .godot/
+.idea/

--- a/client/ClientClock.cs
+++ b/client/ClientClock.cs
@@ -39,11 +39,6 @@ public partial class ClientClock : Node
         _minLatencyInTicks = PhysicsUtils.MsecToTick(_minLatency);
     }
 
-    public override void _Process(double delta)
-    {
-        DisplayDebugInformation();
-    }
-
     // Called every Physics Tick, same as in the server
     public void ProcessTick()
     {
@@ -166,15 +161,16 @@ public partial class ClientClock : Node
         _multiplayer.SendBytes(data, 1, MultiplayerPeer.TransferModeEnum.Unreliable, 1);
     }
 
-    private void DisplayDebugInformation()
+    public void DrawGui()
     {
-        ImGui.Begin("Network Clock Information");
-        ImGui.Text($"Synced Tick {GetCurrentRemoteTick()}");
-        ImGui.Text($"Local Tick {GetCurrentTick()}");
-        ImGui.Text($"Immediate Latency {_immediateLatencyMsec}ms");
-        ImGui.Text($"Average Latency {_averageLatencyInTicks} ticks");
-        ImGui.Text($"Latency Jitter {_jitterInTicks} ticks");
-        ImGui.Text($"Average Offset {_averageOffsetInTicks} ticks");
-        ImGui.End();
+        if (ImGui.CollapsingHeader("Network Clock Information"))
+        {
+            ImGui.Text($"Synced Tick {GetCurrentRemoteTick()}");
+            ImGui.Text($"Local Tick {GetCurrentTick()}");
+            ImGui.Text($"Immediate Latency {_immediateLatencyMsec}ms");
+            ImGui.Text($"Average Latency {_averageLatencyInTicks} ticks");
+            ImGui.Text($"Latency Jitter {_jitterInTicks} ticks");
+            ImGui.Text($"Average Offset {_averageOffsetInTicks} ticks");
+        }
     }
 }

--- a/client/ClientClock.cs
+++ b/client/ClientClock.cs
@@ -118,7 +118,8 @@ public partial class ClientClock : Node
         }
 
         int count = 0;
-        samples.ForEach(s => count += s);
+        for (int i = 0; i < samples.Count; i++)
+            count += samples[i];
         return count / samples.Count;
     }
 

--- a/client/ClientManager.cs
+++ b/client/ClientManager.cs
@@ -41,7 +41,7 @@ public partial class ClientManager : Node
 		_clock.ProcessTick();
 		int currentTick = _clock.GetCurrentTick();
 		int currentRemoteTick = _clock.GetCurrentRemoteTick();
-		CustomSpawner.LocalPlayer.ProcessTick(currentRemoteTick);
+		CustomSpawner.LocalPlayer?.ProcessTick(currentRemoteTick);
 		_snapshotInterpolator.ProcessTick(currentTick);
 	}
 

--- a/client/ClientManager.cs
+++ b/client/ClientManager.cs
@@ -1,6 +1,7 @@
 using Godot;
 using ImGuiNET;
 using MemoryPack;
+using Vector2 = System.Numerics.Vector2;
 
 /*
 	Network manager for the client, handles server connection and routes packages.
@@ -13,12 +14,15 @@ public partial class ClientManager : Node
 	private SceneMultiplayer _multiplayer = new();
 	private SnapshotInterpolator _snapshotInterpolator;
 	private ClientClock _clock;
+	private NetworkDebug _networkDebug;
 	private Node _entityArray;
 
 	public override void _EnterTree()
 	{
 		// Connects to the server
 		ConnectClient();
+
+		_networkDebug = GetNode<NetworkDebug>("Debug");
 
 		_entityArray = GetNode("/root/Main/EntityArray");
 
@@ -33,7 +37,7 @@ public partial class ClientManager : Node
 	public override void _Process(double delta)
 	{
 		_snapshotInterpolator.InterpolateStates(_entityArray);
-		DisplayDebugInformation();
+		DrawGui();
 	}
 
 	public override void _PhysicsProcess(double delta)
@@ -84,11 +88,20 @@ public partial class ClientManager : Node
 		GD.Print("Client connected to ", _address, ":", _port);
 	}
 
-	private void DisplayDebugInformation()
+	private void DrawGui()
 	{
-		ImGui.Begin("Client Information");
-		ImGui.Text($"Framerate {Engine.GetFramesPerSecond()}fps");
-		ImGui.Text($"Physics Tick {Engine.PhysicsTicksPerSecond}hz");
+		ImGui.SetNextWindowPos(Vector2.Zero);
+		if (ImGui.Begin("Client Information", 
+			    ImGuiWindowFlags.NoMove
+			    | ImGuiWindowFlags.NoResize
+			    | ImGuiWindowFlags.AlwaysAutoResize))
+		{
+			ImGui.Text($"Framerate {Engine.GetFramesPerSecond()}fps");
+			ImGui.Text($"Physics Tick {Engine.PhysicsTicksPerSecond}hz");
+			_clock.DrawGui();
+			_networkDebug.DrawGui();
+			_snapshotInterpolator.DrawGui();
+		}
 		ImGui.End();
 	}
 }

--- a/client/ClientPlayer.cs
+++ b/client/ClientPlayer.cs
@@ -64,7 +64,7 @@ public partial class ClientPlayer : CharacterBody3D
         else return;
 
         // Delete all stored inputs up to that point, we don't need them anymore
-        for (int i = _userInputs.Count-1; i <= 0; i--)
+        for (int i = _userInputs.Count-1; i >= 0; i--)
             if (_userInputs[i].Tick <= forTick)
                 _userInputs.RemoveAt(i);
 

--- a/client/ClientPlayer.cs
+++ b/client/ClientPlayer.cs
@@ -4,6 +4,7 @@ using Godot;
 using ImGuiNET;
 using MemoryPack;
 using NetMessage;
+using Vector2 = System.Numerics.Vector2;
 
 /*
     Main player script, send movement packets to the server, does CSP, and reconciliation.
@@ -22,11 +23,6 @@ public partial class ClientPlayer : CharacterBody3D
     public override void _Ready()
     {
         _networkId = Multiplayer.GetUniqueId();
-    }
-
-    public override void _Process(double delta)
-    {
-        DisplayDebugInformation();
     }
 
     public void ProcessTick(int currentTick)
@@ -148,15 +144,13 @@ public partial class ClientPlayer : CharacterBody3D
         return userInput;
     }
 
-    private void DisplayDebugInformation()
+    public void DrawGui()
     {
-        ImGui.Begin("Player Network Information");
         ImGui.Text($"Network Id {_networkId}");
         ImGui.Text($"Position {Position.Snapped(Vector3.One * 0.01f)}");
         ImGui.Text($"Redundant Inputs {_userInputs.Count}");
         ImGui.Text($"Last Stamp Rec. {_lastStampReceived}");
         ImGui.Text($"Misspredictions {_misspredictionCounter}");
         ImGui.Checkbox("Automove?", ref _autoMoveEnabled);
-        ImGui.End();
     }
 }

--- a/client/SnapshotInterpolator.cs
+++ b/client/SnapshotInterpolator.cs
@@ -26,7 +26,6 @@ public partial class SnapshotInterpolator : Node
         smooth out the interpolation, I still believe that it is not as smooth as it was when using
         Time.GetTicksMsec() so this is still pending, but is good enough for now.*/
         _currentTick += delta / PhysicsUtils.FrameTime;
-        DisplayDebugInformation();
     }
 
     public void ProcessTick(int currentTick)
@@ -61,7 +60,7 @@ public partial class SnapshotInterpolator : Node
             {
                 //TODO: check if the Entity is available in both states
                 NetMessage.EntityState futureState = nextSnapshot.States[i];
-                NetMessage.EntityState pastState = prevSnapshot.States[i];
+                NetMessage.EntityState pastState = prevSnapshot.States.Length < i ? prevSnapshot.States[i] : futureState;
 
                 var dummy = CustomSpawner.GetSpawnedNode(futureState.Id);
 
@@ -86,17 +85,16 @@ public partial class SnapshotInterpolator : Node
         _bufferTime = bufferTime + _minBufferTime;
     }
 
-    private void DisplayDebugInformation()
+    public void DrawGui()
     {
-        ImGui.Begin("Snapshot Interpolator Information");
+        if (ImGui.CollapsingHeader("Snapshot Interpolator Information"))
+        {
+            if (_interpolationFactor > 1) ImGui.PushStyleColor(ImGuiCol.Text, 0xFF0000FF);
+            ImGui.Text($"Interp. Factor {_interpolationFactor:0.00}");
+            ImGui.PopStyleColor();
 
-        if (_interpolationFactor > 1) ImGui.PushStyleColor(ImGuiCol.Text, 0xFF0000FF);
-        ImGui.Text($"Interp. Factor {_interpolationFactor:0.00}");
-        ImGui.PopStyleColor();
-
-        ImGui.Text($"Buffer Size {_snapshotBuffer.Count} snapshots");
-        ImGui.Text($"Buffer Time {_bufferTime} ticks");
-        ImGui.End();
+            ImGui.Text($"Buffer Size {_snapshotBuffer.Count} snapshots");
+            ImGui.Text($"Buffer Time {_bufferTime} ticks");
+        }
     }
-
 }

--- a/client/SnapshotInterpolator.cs
+++ b/client/SnapshotInterpolator.cs
@@ -63,7 +63,7 @@ public partial class SnapshotInterpolator : Node
                 NetMessage.EntityState futureState = nextSnapshot.States[i];
                 NetMessage.EntityState pastState = prevSnapshot.States[i];
 
-                var dummy = playersArray.GetNode<Node3D>(futureState.Id.ToString()); //FIXME: remove GetNode for the love of god
+                var dummy = CustomSpawner.GetSpawnedNode(futureState.Id);
 
                 if (dummy != null && dummy.IsMultiplayerAuthority() == false)
                 {

--- a/multiplayer-base.csproj
+++ b/multiplayer-base.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.2.1">
+<Project Sdk="Godot.NET.Sdk/4.2.2">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/server/ServerClock.cs
+++ b/server/ServerClock.cs
@@ -1,7 +1,7 @@
 using Godot;
 using ImGuiNET;
 using MemoryPack;
-using System;
+using NetMessage;
 
 public partial class ServerClock : Node
 {
@@ -21,7 +21,6 @@ public partial class ServerClock : Node
 
 	public override void _Process(double delta)
 	{
-		DisplayDebugInformation();
 		SolveSendNetworkTickEvent(delta);
 	}
 
@@ -49,20 +48,21 @@ public partial class ServerClock : Node
 	// When we receive a sync packet from a Client, we return it with the current Clock data
 	private void OnPacketReceived(long id, byte[] data)
 	{
-		var command = MemoryPackSerializer.Deserialize<NetMessage.ICommand>(data);
+		var command = MemoryPackSerializer.Deserialize<ICommand>(data);
 
-		if (command is NetMessage.Sync sync)
+		if (command is Sync sync)
 		{
 			sync.ServerTime = _currentTick;
-			_multiplayer.SendBytes(MemoryPackSerializer.Serialize<NetMessage.ICommand>(sync), (int)id, MultiplayerPeer.TransferModeEnum.Unreliable, 1);
+			_multiplayer.SendBytes(MemoryPackSerializer.Serialize<ICommand>(sync), (int)id, MultiplayerPeer.TransferModeEnum.Unreliable, 1);
 		}
 	}
 
-	private void DisplayDebugInformation()
+	public void DrawGui()
 	{
-		ImGui.Begin($"Clock Information");
-		ImGui.Text($"Network Tickrate {GetNetworkTickRate()}hz");
-		ImGui.Text($"Current Tick {_currentTick}");
-		ImGui.End();
+		if (ImGui.CollapsingHeader("Clock Information"))
+		{
+			ImGui.Text($"Network Tickrate {GetNetworkTickRate()}hz");
+			ImGui.Text($"Current Tick {_currentTick}");
+		}
 	}
 }

--- a/server/ServerManager.cs
+++ b/server/ServerManager.cs
@@ -9,7 +9,7 @@ public partial class ServerManager : Node
 	[Export] private int _port = 9999;
 
 	private SceneMultiplayer _multiplayer = new();
-	private Godot.Collections.Array<Godot.Node> entityArray;
+	private Godot.Collections.Array<Godot.Node> entityArray = new();
 	private ServerClock _serverClock;
 
 	private int _currentTick = 0;

--- a/server/ServerManager.cs
+++ b/server/ServerManager.cs
@@ -68,7 +68,7 @@ public partial class ServerManager : Node
 		var command = MemoryPackSerializer.Deserialize<NetMessage.ICommand>(data);
 		if (command is NetMessage.UserCommand userCommand)
 		{
-			ServerPlayer player = GetNode($"/root/Main/EntityArray/{id}") as ServerPlayer; //FIXME: do not use GetNode here
+			ServerPlayer player = CustomSpawner.GetSpawnedNode((int)id) as ServerPlayer;
 			player.PushCommand(userCommand);
 		}
 

--- a/server/ServerManager.cs
+++ b/server/ServerManager.cs
@@ -11,18 +11,20 @@ public partial class ServerManager : Node
 	private SceneMultiplayer _multiplayer = new();
 	private Godot.Collections.Array<Godot.Node> entityArray = new();
 	private ServerClock _serverClock;
+	private NetworkDebug _networkDebug;
 
 	private int _currentTick = 0;
 	public override void _EnterTree()
 	{
 		StartListening();
+		_networkDebug = GetNode<NetworkDebug>("Debug");
 		_serverClock = GetNode<ServerClock>("ServerClock");
 		_serverClock.NetworkProcessTick += NetworkProcess;
 	}
 
 	public override void _Process(double delta)
 	{
-		DisplayDebugInformation();
+		DrawGui();
 	}
 
 	public override void _PhysicsProcess(double delta)
@@ -105,11 +107,19 @@ public partial class ServerManager : Node
 		GD.Print("Server listening on ", _port);
 	}
 
-	private void DisplayDebugInformation()
+	private void DrawGui()
 	{
-		ImGui.Begin("Server Information");
-		ImGui.Text($"Framerate {Engine.GetFramesPerSecond()}fps");
-		ImGui.Text($"Physics Tick {Engine.PhysicsTicksPerSecond}hz");
+		ImGui.SetNextWindowPos(System.Numerics.Vector2.Zero);
+		if(ImGui.Begin("Server Information", 
+			ImGuiWindowFlags.NoMove
+			| ImGuiWindowFlags.NoResize
+			| ImGuiWindowFlags.AlwaysAutoResize))
+		{
+			ImGui.Text($"Framerate {Engine.GetFramesPerSecond()}fps");
+			ImGui.Text($"Physics Tick {Engine.PhysicsTicksPerSecond}hz");
+			_serverClock.DrawGui();
+			_networkDebug.DrawGui();
+		}
 		ImGui.End();
 	}
 }

--- a/server/ServerPlayer.cs
+++ b/server/ServerPlayer.cs
@@ -16,11 +16,6 @@ public partial class ServerPlayer : CharacterBody3D
 	private LocalInput? _lastInputProcessed = null;
 #nullable disable
 
-	public override void _Process(double delta)
-	{
-		DisplayDebugInformation();
-	}
-
 	public void ProcessPendingCommands(int currentTick)
 	{
 		if (TryGetInput(currentTick, out var input))
@@ -101,12 +96,13 @@ public partial class ServerPlayer : CharacterBody3D
 		};
 	}
 
-	private void DisplayDebugInformation()
+	public void DrawGui()
 	{
-		ImGui.Begin($"Server Player {MultiplayerID}");
-		ImGui.Text($"Instant Latency {InstantLatency}");
-		ImGui.Text($"Input Queue Count {_inputQueueSize}");
-		ImGui.Text($"Missed Frames {_skippedTicks}");
-		ImGui.End();
+		if (ImGui.CollapsingHeader($"Server Player: {MultiplayerID}"))
+		{
+			ImGui.Text($"Instant Latency {InstantLatency}");
+			ImGui.Text($"Input Queue Count {_inputQueueSize}");
+			ImGui.Text($"Missed Frames {_skippedTicks}");
+		}
 	}
 }

--- a/shared/CustomSpawner.cs
+++ b/shared/CustomSpawner.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using Godot;
+using ImGuiNET;
+using Vector2 = System.Numerics.Vector2;
 
 public partial class CustomSpawner : MultiplayerSpawner
 {
@@ -16,6 +18,12 @@ public partial class CustomSpawner : MultiplayerSpawner
         this.SpawnFunction = customSpawnFunctionCallable;
 
         this.SetMultiplayerAuthority(Multiplayer.GetUniqueId());
+    }
+
+    public override void _Process(double delta)
+    {
+        base._Process(delta);
+        DrawGui();
     }
 
     public static Node3D GetSpawnedNode(int id)
@@ -63,5 +71,33 @@ public partial class CustomSpawner : MultiplayerSpawner
             _spawnedNodes.Add(spawnedPlayerID, player);
             return player;
         }
+    }
+
+    private static void DrawGui()
+    {
+        if (_spawnedNodes.Count == 0)
+            return;
+        
+        var io = ImGui.GetIO();
+        ImGui.SetNextWindowPos(io.DisplaySize with { Y= 0}, ImGuiCond.Always, new Vector2(1, 0));
+        if (ImGui.Begin("Player Information",
+                ImGuiWindowFlags.NoMove
+                | ImGuiWindowFlags.NoResize
+                | ImGuiWindowFlags.AlwaysAutoResize))
+        {
+            foreach (var nodesValue in _spawnedNodes.Values)
+            {
+                switch (nodesValue)
+                {
+                    case ServerPlayer serverPlayer:
+                        serverPlayer.DrawGui();
+                        break;
+                    case ClientPlayer clientPlayer:
+                        clientPlayer.DrawGui();
+                        break;
+                }
+            }
+        }
+        ImGui.End();
     }
 }

--- a/shared/CustomSpawner.cs
+++ b/shared/CustomSpawner.cs
@@ -1,5 +1,5 @@
+using System.Collections.Generic;
 using Godot;
-using System;
 
 public partial class CustomSpawner : MultiplayerSpawner
 {
@@ -7,7 +7,8 @@ public partial class CustomSpawner : MultiplayerSpawner
     [Export] private PackedScene _serverPlayerScene;
     [Export] private PackedScene _dummyScene;
 
-    public static ClientPlayer LocalPlayer;
+    private static readonly Dictionary<int, Node3D> _spawnedNodes = new();
+    public static ClientPlayer LocalPlayer { get; private set; }
 
     public override void _Ready()
     {
@@ -15,6 +16,11 @@ public partial class CustomSpawner : MultiplayerSpawner
         this.SpawnFunction = customSpawnFunctionCallable;
 
         this.SetMultiplayerAuthority(Multiplayer.GetUniqueId());
+    }
+
+    public static Node3D GetSpawnedNode(int id)
+    {
+        return _spawnedNodes.GetValueOrDefault(id);
     }
 
     // This method is called on all Clients after someone joins the server,
@@ -28,9 +34,10 @@ public partial class CustomSpawner : MultiplayerSpawner
         if (localID == 1)
         {
             GD.Print("Spawned server character");
-            ServerPlayer player = _serverPlayerScene.Instantiate() as ServerPlayer;
+            ServerPlayer player = _serverPlayerScene.Instantiate<ServerPlayer>();
             player.Name = spawnedPlayerID.ToString();
             player.MultiplayerID = spawnedPlayerID;
+            _spawnedNodes.Add(spawnedPlayerID, player);
             return player;
         }
 
@@ -38,10 +45,11 @@ public partial class CustomSpawner : MultiplayerSpawner
         if (localID == spawnedPlayerID)
         {
             GD.Print("Spawned client player");
-            ClientPlayer player = _playerScene.Instantiate() as ClientPlayer;
+            ClientPlayer player = _playerScene.Instantiate<ClientPlayer>();
             player.Name = spawnedPlayerID.ToString();
             player.SetMultiplayerAuthority(spawnedPlayerID);
             LocalPlayer = player;
+            _spawnedNodes.Add(spawnedPlayerID, player);
             return player;
         }
 
@@ -49,9 +57,10 @@ public partial class CustomSpawner : MultiplayerSpawner
         // is from someone else: spawn dummy player
         {
             GD.Print("Spawned dummy");
-            Node player = _dummyScene.Instantiate();
+            Node3D player = _dummyScene.Instantiate<Node3D>();
             player.Name = spawnedPlayerID.ToString();
             player.SetMultiplayerAuthority(spawnedPlayerID);
+            _spawnedNodes.Add(spawnedPlayerID, player);
             return player;
         }
     }

--- a/shared/LocalInput.cs
+++ b/shared/LocalInput.cs
@@ -1,0 +1,9 @@
+
+/// <summary>
+/// Input from the Client
+/// </summary>
+public struct LocalInput
+{
+    public int Tick;
+    public byte Input;
+}

--- a/shared/NetworkDebug.cs
+++ b/shared/NetworkDebug.cs
@@ -1,5 +1,6 @@
 using Godot;
 using ImGuiNET;
+using Vector2 = System.Numerics.Vector2;
 
 /*
 	This node calculates and displays some general Debug data.
@@ -21,11 +22,6 @@ public partial class NetworkDebug : Control
 		timer.Start();
 	}
 
-	public override void _Process(double delta)
-	{
-		DisplayDebugInformation();
-	}
-
 	private void OnTimerOut()
 	{
 		var enetHost = (Multiplayer.MultiplayerPeer as ENetMultiplayerPeer).Host;
@@ -35,13 +31,14 @@ public partial class NetworkDebug : Control
 		_sentPacketsPerSecond = enetHost.PopStatistic(ENetConnection.HostStatistic.SentPackets);
 	}
 
-	private void DisplayDebugInformation()
+	public void DrawGui()
 	{
-		ImGui.Begin("General Network per Second");
-		ImGui.Text($"Sent Bytes {_sentPerSecond}");
-		ImGui.Text($"Rec. Bytes {_recPerSecond}");
-		ImGui.Text($"Packets Sent {_sentPacketsPerSecond}");
-		ImGui.Text($"Packets Rec. {_receivedPacketsPerSecond}");
-		ImGui.End();
+		if (ImGui.CollapsingHeader("General Network per Second"))
+		{
+			ImGui.Text($"Sent Bytes {_sentPerSecond}");
+			ImGui.Text($"Rec. Bytes {_recPerSecond}");
+			ImGui.Text($"Packets Sent {_sentPacketsPerSecond}");
+			ImGui.Text($"Packets Rec. {_receivedPacketsPerSecond}");
+		}
 	}
 }


### PR DESCRIPTION
This PR reduces allocations caused by LINQ lambda expressions. 
Generally this is not too much of an issue, but for code that is executing a lot it causes extra garbage that you don't want hanging around. GC needs to work harder.

EDIT

Just added some more commits. They really should be different PRs but I just realised when I pushed it put them into this with one... oops.

Extra things
- Remove GetNode calls in some places
- Consolidated the ImGui drawing so its all in a single window